### PR TITLE
use refreshing from props if specified

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -66,7 +66,7 @@ function MasonryList<T>(props: Props<T>): ReactElement {
       removeClippedSubviews={true}
       refreshControl={
         <RefreshControl
-          refreshing={!!(refreshing && isRefreshing)}
+          refreshing={!!(refreshing || isRefreshing)}
           onRefresh={() => {
             setIsRefreshing(true);
             onRefresh?.();


### PR DESCRIPTION
## Description

In current version, even if refreshing prop is specified, MasonryList component does not care about the value of this prop. Reason is that **(refreshing && isRefreshing)** evaluates to false if isRefreshing is false and it is set to false just after onRefresh callback.

So, using **||** instead of **&&** solves this problem because it prioritizes the value of refreshing from props, if there is no prop, it can continue to use value from state.
