### PR TITLE
fix: React: ref is not a prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Our `MasonryList` view component is able to render all child views with all diff
 ## Props
 
 ```tsx
+innerRef?: MutableRefObject<ScrollView | undefined>;
 keyPrefix?: string;
 loading?: boolean;
 refreshing?: RefreshControlProps['refreshing'];
@@ -70,6 +71,8 @@ ListEmptyComponent?: React.ComponentType<any> | React.ReactElement | null;
 ListFooterComponent?: React.ComponentType<any> | React.ReactElement | null;
 numColumns?: number;
 ```
+
+**`innerRef`** -            Expose ScrollView instance with `ref`, example usage:  `ref.current.scrollTo`.
 
 **`keyPrefix`** -             Add prefix for keying child views. This is currently incremented by `1`.
 

--- a/index.tsx
+++ b/index.tsx
@@ -12,7 +12,7 @@ import React, {MutableRefObject, ReactElement, memo, useState} from 'react';
 
 interface Props<T>
   extends Omit<ScrollViewProps, 'refreshControl' | 'onScroll'> {
-  ref?: MutableRefObject<ScrollView | undefined>;
+  innerRef?: MutableRefObject<ScrollView | undefined>;
   keyPrefix?: string;
   loading?: boolean;
   refreshing?: RefreshControlProps['refreshing'];
@@ -48,7 +48,7 @@ function MasonryList<T>(props: Props<T>): ReactElement {
     keyPrefix,
     refreshing,
     data,
-    ref,
+    innerRef,
     ListHeaderComponent,
     ListEmptyComponent,
     ListFooterComponent,
@@ -66,7 +66,7 @@ function MasonryList<T>(props: Props<T>): ReactElement {
   return (
     <ScrollView
       {...props}
-      ref={ref}
+      ref={innerRef}
       style={[{flex: 1, alignSelf: 'stretch'}, style]}
       removeClippedSubviews={true}
       refreshControl={


### PR DESCRIPTION
## Description

Wants to control the MasonryList to scroll to top, so need to use `ref`.
When use `ref`:
1. Got error:
> React: ref is not a prop

2. ref.current is undefined

## Related Issues

https://github.com/facebook/react/pull/5744
https://stackoverflow.com/questions/38089895/react-ref-is-not-a-prop

