### PR TITLE
Fix `keyExtractor` placed on parent view

### DIFF
--- a/__tests__/__snapshots__/MasonryList.test.tsx.snap
+++ b/__tests__/__snapshots__/MasonryList.test.tsx.snap
@@ -58,11 +58,21 @@ exports[`Rendering should render without crashing 1`] = `
           }
         }
       >
-        <View />
-        <View />
-        <View />
-        <View />
-        <View />
+        <View>
+          <View />
+        </View>
+        <View>
+          <View />
+        </View>
+        <View>
+          <View />
+        </View>
+        <View>
+          <View />
+        </View>
+        <View>
+          <View />
+        </View>
       </View>
       <View
         style={
@@ -72,11 +82,21 @@ exports[`Rendering should render without crashing 1`] = `
           }
         }
       >
-        <View />
-        <View />
-        <View />
-        <View />
-        <View />
+        <View>
+          <View />
+        </View>
+        <View>
+          <View />
+        </View>
+        <View>
+          <View />
+        </View>
+        <View>
+          <View />
+        </View>
+        <View>
+          <View />
+        </View>
       </View>
     </View>
   </View>

--- a/index.tsx
+++ b/index.tsx
@@ -28,7 +28,7 @@ interface Props<T> extends Omit<ScrollViewProps, 'refreshControl'> {
   contentContainerStyle?: StyleProp<ViewStyle>;
   containerStyle?: StyleProp<ViewStyle>;
   numColumns?: number;
-  keyExtractor?: ((item: T, index: number) => string) | undefined;
+  keyExtractor?: ((item: T | any, index: number) => string) | undefined;
 }
 
 const isCloseToBottom = (
@@ -117,7 +117,7 @@ function MasonryList<T>(props: Props<T>): ReactElement {
           {Array.from(Array(numColumns), (_, num) => {
             return (
               <View
-                key={keyExtractor?.(_, num)}
+                key={`masonry-column-${num}`}
                 style={{
                   flex: 1 / numColumns,
                   flexDirection: horizontal ? 'row' : 'column',
@@ -126,7 +126,11 @@ function MasonryList<T>(props: Props<T>): ReactElement {
                 {data
                   .map((el, i) => {
                     if (i % numColumns === num)
-                      return renderItem({item: el, i});
+                      return (
+                        <View key={keyExtractor?.(el, i)}>
+                          {renderItem({item: el, i})}
+                        </View>
+                      );
 
                     return null;
                   })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@react-native-seoul/masonry-list",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "React Native Masonry List for Pinterest like UI implemented just like the [FlatList].",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
## Description

In `1.2.0` and `1.2.1`, the `keyExtractor` was placed in the wrong view. Place this to correct child view.

Sorry for inconvenience 🙏

## Related Issues

#10 

## Tests

N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/hyochan/react-native-masonry-list/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [x] Run `yarn lint && yarn tsc`
- [x] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [x] I am willing to follow-up on review comments in a timely manner.
