### PR TITLE
data could be readonly

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -18,7 +18,7 @@ interface Props<T> extends Omit<ScrollViewProps, 'refreshControl'> {
   onEndReached?: () => void;
   onEndReachedThreshold?: number;
   style?: StyleProp<ViewStyle>;
-  data: T[];
+  data: readonly T[];
   renderItem: ({item: T, i: number}) => ReactElement;
   LoadingView?: React.ComponentType<any> | React.ReactElement | null;
   ListHeaderComponent?: React.ComponentType<any> | React.ReactElement | null;


### PR DESCRIPTION
## Description

We have some relay types that are marked as `readonly`, and `MasonryList` is complaining that `data` is `readonly` when it expects `mutable`. `data` is not really doing any changes, so we might as well mark it `readonly`. cc @patrinoua

## Related Issues

_Replace this paragraph with a list of issues related to this PR from our [issue database]. Indicate, which of these issues are resolved or fixed by this PR._

## Tests

I added the following tests:

_Replace this with a list of the tests that you added as part of this PR. A change in behavior with no test covering it
will likely get reverted accidentally sooner or later. PRs must include tests for all changed/updated/fixed behaviors. See [Test Coverage](https://app.codecov.io/gh/hyochan/react-native-masonry-list)._

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide](https://github.com/hyochan/react-native-masonry-list/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ] Run `yarn lint && yarn tsc`
- [ ] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [ ] I am willing to follow-up on review comments in a timely manner.
