### PR TITLE
Fix for onEndReached not getting called

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -39,7 +39,7 @@ const isCloseToBottom = (
   const paddingToBottom = contentSize.height * onEndReachedThreshold;
 
   return (
-    layoutMeasurement.height + contentOffset.y >=
+    Math.ceil(layoutMeasurement.height + contentOffset.y) >=
     contentSize.height - paddingToBottom
   );
 };
@@ -93,7 +93,7 @@ function MasonryList<T>(props: Props<T>): ReactElement {
         ) : null
       }
       scrollEventThrottle={16}
-      onScroll={(e) => {
+      onMomentumScrollEnd={(e) => {
         const nativeEvent: NativeScrollEvent = e.nativeEvent;
         if (isCloseToBottom(nativeEvent, onEndReachedThreshold || 0.0)) {
           onEndReached?.();


### PR DESCRIPTION
## Description

This PR focuses on fixing the onEndReached not getting called, this happens due to the line below
`layoutMeasurement.height + contentOffset.y >= contentSize.height - paddingToBottom`

Where both sides might resolve to a 6+ decimal place number which introduces inaccuracy because of the three different measurements. The fix I have applied is to remove the decimal places from the left hand side by using Math.ceil. This will evaluate to end reached if its on the bottom of the screen regardless of decimal points.

## Related Issues

N/A

## Tests

N/A

## Checklist


- [✔️  ] I read the [Contributor Guide](https://github.com/hyochan/react-native-masonry-list/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ✔️ ] Run `yarn lint && yarn tsc`
- [ ] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [ ✔️ ] I am willing to follow-up on review comments in a timely manner.
