### PR TITLE
Fix for onEndReached not getting called

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -39,7 +39,7 @@ const isCloseToBottom = (
   const paddingToBottom = contentSize.height * onEndReachedThreshold;
 
   return (
-    layoutMeasurement.height + contentOffset.y >=
+    Math.ceil(layoutMeasurement.height + contentOffset.y) >=
     contentSize.height - paddingToBottom
   );
 };


### PR DESCRIPTION
## Description

This PR focuses on fixing onEndReached not getting called. The reason why it sometimes doesn't get called is because of this particular line 

`layoutMeasurement.height + contentOffset.y >= contentSize.height - paddingToBottom`

Where both sides sometimes evaluate to a 6 decimal place number and because of three different measurements (height,offset, total height), comparing them introduces inaccuracy. For example if the 6th decimal point is 0 on left hand side and its 1 on right hand side. Then even if we are at the end, this function will not get called because the fore mentioned line will evaluate to false. To fix this, I have removed the decimal points from the left hand side by using Math.Ceil. This will call the function by removing uncertainties of the decimal points.
 

## Related Issues

N/A

## Tests

N/A

## Checklist

Before you create this PR confirms that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [✅ ] I read the [Contributor Guide](https://github.com/hyochan/react-native-masonry-list/blob/main/CONTRIBUTING.md) and followed the process outlined there for submitting PRs.
- [ ✅ ] Run `yarn lint && yarn tsc`
- [ ] Run `yarn test` or `yarn test -u` if you need to update snapshot.
- [ ✅ ] I am willing to follow-up on review comments in a timely manner.
